### PR TITLE
Fix issue #4 - "Use the first image's load event instead of the window's event"

### DIFF
--- a/karusel/karusel.js
+++ b/karusel/karusel.js
@@ -28,7 +28,7 @@ karuselTrack.style.transform = `translateX(${transformValue}px)`;
 // Event handlers
 /////////////////////
 
-window.addEventListener('load', function () {
+imageSample.addEventListener('load', function () {
   imageWidth = imageSample.width;
   karuselTrack.width = imageWidth; /* isso não funciona */
   return imageWidth;


### PR DESCRIPTION
Fix issue #4, quoted:

"If you get the image's width on the window's load event here:
`window.addEventListener('load', function () {`
the karusel will work only after all images of the page (both related and non-related to the karusel) are completely loaded. If you add the event listener to the karusel's first image instead, you'll get the width as soon as that image is loaded. This will allow the user to interact with the page faster."

Apply the event listener to the `imageSample` variable instead.