### PR TITLE
Tweaks: returns, placeholder images, track width and wrapper width

### DIFF
--- a/karusel/karusel.css
+++ b/karusel/karusel.css
@@ -7,10 +7,6 @@
   float: left;
 }
 
-.karusel-track {
-  width: 3000px;
-}
-
 .karusel-prev {
   padding: 9px;
   border-radius: 16px;
@@ -29,4 +25,8 @@
   right: 20px;
   position: absolute;
   cursor: pointer;
+}
+
+.temp-frame {
+  width: 1000px;
 }

--- a/karusel/karusel.js
+++ b/karusel/karusel.js
@@ -23,25 +23,21 @@ nextBtn.classList.add('karusel-next');
 var transformValue = -560;
 karuselTrack.style.transform = `translateX(${transformValue}px)`;
 
-
 /////////////////////
 // Event handlers
 /////////////////////
 
 imageSample.addEventListener('load', function () {
   imageWidth = imageSample.width;
-  karuselTrack.width = imageWidth; /* isso não funciona */
-  return imageWidth;
-}); /* por que isso só funciona sem declarar var? declarado lá em cima ao invés */
+  karuselTrack.style.width = `${imageWidth * 3}px`;
+});
 
 prevBtn.addEventListener('click', function () {
   transformValue = transformValue + imageWidth;
   karuselTrack.style.transform = `translateX(${transformValue}px)`;
-  return transformValue;
 });
 
 nextBtn.addEventListener('click', function () {
   transformValue = transformValue - imageWidth;
   karuselTrack.style.transform = `translateX(${transformValue}px)`;
-  return transformValue;
 });

--- a/sample.html
+++ b/sample.html
@@ -13,16 +13,18 @@
 
   <body>
 
-  <div id="karusel">
-    <div>
+  <div class="temp-frame">
+    <div id="karusel">
       <div>
-        <img src="https://placeimg.com/700/700/animals/grayscale">
-      </div>
-      <div>
-        <img src="https://placeimg.com/700/700/animals/grayscale">
-      </div>
-      <div>
-        <img src="https://placeimg.com/700/700/animals/grayscale">
+        <div>
+          <img src="https://placeimg.com/700/700/animals/grayscale?aswq">
+        </div>
+        <div>
+          <img src="https://placeimg.com/700/700/animals/grayscale?1232">
+        </div>
+        <div>
+          <img src="https://placeimg.com/700/700/animals/grayscale?swer">
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Add a few improvements:
- Remove `return` from `imageSample`, `prevBtn` and `nextBtn` event listeners, as these values weren't used anywhere.
- Randomize image placeholders in the URL to make them more distinguishable.
- Add `px` to the expression that defines the `karuselTrack` width and multiply the value by 3 to temporarily make it work.
- Remove the width declaration from the CSS as it's no longer needed.
- Add a temporary wrapper `<div>` to define a limited width of 1000px instead of having to resize the window when debugging.